### PR TITLE
Properly implement Elite Bionics Framework compatibility

### DIFF
--- a/Source/CM_Callouts/Patches/DamageWorker_DamageResult_AssociateWithLog.cs
+++ b/Source/CM_Callouts/Patches/DamageWorker_DamageResult_AssociateWithLog.cs
@@ -64,7 +64,7 @@ public static class DamageWorker_DamageResult_AssociateWithLog
             else
             {
                 var partHealth = pawn.health.hediffSet.GetPartHealth(recipientPartsDamaged[i]);
-                var partMaxHealth = recipientPartsDamaged[i].def.GetMaxHealth(pawn);
+                var partMaxHealth = MaxHealthGetter.GetMaxHealth(recipientPartsDamaged[i], pawn);
                 var partPercentHealth = partHealth / partMaxHealth;
                 bool showWound;
 

--- a/Source/CM_Callouts/Patches/MaxHealthGetter.cs
+++ b/Source/CM_Callouts/Patches/MaxHealthGetter.cs
@@ -6,7 +6,7 @@ using Verse;
 namespace CM_Callouts;
 
 [HarmonyPatch]
-public class EBFEndpoints_GetMaxHealthWithEBF
+public class MaxHealthGetter
 {
     public static bool Prepare()
     {


### PR DESCRIPTION
This continues #1.

The docs at Elite Bionics Framework was incomplete; after creating the reverse-patch class, the code base still needs to call the reverse-patched method to finally use the EBF-compliant method.

Indeed, #1 mentions some transpilers that needs to be updated at EBF's side. This will be handled by EBF internals as EBF thinks about how best to approach it.

As such, this PR is currently a draft.